### PR TITLE
Add option to configure the init container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add option to configure the init container image
 
 ## [0.1.2] - 2019-08-23
 ### Fixed

--- a/src/main/helm/artemis/templates/_helpers.tpl
+++ b/src/main/helm/artemis/templates/_helpers.tpl
@@ -71,7 +71,8 @@ app.kubernetes.io/ha: backup
 {{- define "artemis.statefulset.spec" -}}
 initContainers:
 - name: copy-broker-config
-  image: bash:5
+  image: {{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}
+  imagePullPolicy: {{ .Values.initContainerImage.pullPolicy}}
   command:
     - bash
   args:
@@ -83,7 +84,8 @@ initContainers:
   - name: etc-override
     mountPath: /tmp/etc-override
 - name: set-pod-ip
-  image: bash:5
+  image: {{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}
+  imagePullPolicy: {{ .Values.initContainerImage.pullPolicy}}
   command:
     - bash
   args:

--- a/src/main/helm/artemis/values.yaml
+++ b/src/main/helm/artemis/values.yaml
@@ -6,6 +6,11 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+initContainerImage:
+  repository: bash
+  tag: 5
+  pullPolicy: IfNotPresent
+
 resources:
   limits:
     memory: 256Mi


### PR DESCRIPTION
To use this helm chart in an on-premise installation without internet access we need to be able to change the image repository.

This PR allows for a dynamic configuration of the previously hard-coded image.