### PR TITLE
Fix role bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove namespaces from roleRef and subjects as the namespace is defined for whole RoleBinding
 
 ## [0.2.0] - 2020-05-20
 ### Changed

--- a/src/main/helm/artemis/templates/role-binding.yaml
+++ b/src/main/helm/artemis/templates/role-binding.yaml
@@ -2,12 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ include "artemis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "artemis.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "artemis.fullname" . }}
-  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
In RoleBinding resource, roleRef and subjects don't have "namespace" field as they should exist in same namespace as the RoleBinding, therefore only RoleBinding can have "namespace" field. Otherwise error:
`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(RoleBinding.roleRef): unknown field "namespace" in io.k8s.api.rbac.v1beta1.RoleRef
`