### PR TITLE
Change 'empty' volume type to 'emptyDir'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Remove namespaces from roleRef and subjects as the namespace is defined for whole RoleBinding
+- Change 'empty' volume type to 'emptyDir'
 
 ## [0.2.0] - 2020-05-20
 ### Changed

--- a/src/main/helm/artemis/templates/_helpers.tpl
+++ b/src/main/helm/artemis/templates/_helpers.tpl
@@ -183,7 +183,7 @@ imagePullSecrets:
 {{- end }}
 volumes:
 - name: etc-override
-  empty: {}
+  emptyDir: {}
 - name: jgroups
   configMap:
     name: {{ include "artemis.fullname" . }}
@@ -192,7 +192,7 @@ volumes:
       path: jgroups-discovery.xml
 {{- if not .Values.persistence.enabled }}
 - name: data
-  empty: {}
+  emptyDir: {}
 {{- end }}
 - name: config
   configMap:


### PR DESCRIPTION
With 'empty' type following error occurs:

> Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.volumes[0]): unknown field "empty" in io.k8s.api.core.v1.Volume
