### PR TITLE
Configure artemis users and roles via helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove namespaces from roleRef and subjects as the namespace is defined for whole RoleBinding
 - Change 'empty' volume type to 'emptyDir'
 
+### Added
+- Add option to configure artemis users, credentials and roles 
+
 ## [0.2.0] - 2020-05-20
 ### Changed
 - Add option to configure the init container image

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,14 @@
                     <chartRepoUrl>${helm.repository.url}</chartRepoUrl>
                     <helmVersion>2.14.3</helmVersion>
                     <skipSnapshots>false</skipSnapshots>
+                    <valuesFile>src/test/helm/artemis/values.yaml</valuesFile>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>package</goal>
                             <goal>lint</goal>
+                            <goal>template</goal>
                             <goal>deploy</goal>
                         </goals>
                     </execution>

--- a/src/main/helm/artemis/templates/_helpers.tpl
+++ b/src/main/helm/artemis/templates/_helpers.tpl
@@ -99,6 +99,39 @@ initContainers:
   volumeMounts:
   - name: etc-override
     mountPath: /tmp/etc-override
+- name: set-users
+  image: {{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}
+  imagePullPolicy: {{ .Values.initContainerImage.pullPolicy}}
+  env:
+    {{- $releaseName := .Release.Name }}
+    {{- range $user, $properties := .Values.users }}
+    - name: ARTEMIS_USER_PW_{{ $user | upper | replace "-" "_" }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ $releaseName }}-{{ $properties.secretName  }}
+          key: {{ $properties.secretKey }}
+    {{- end }}
+  command:
+    - sh
+    - "-c"
+    - |
+      bash <<'EOF'
+      touch /tmp/artemis/artemis-users.properties /tmp/artemis/artemis-roles.properties
+      {{- range $user, $properties := .Values.users }}
+      echo "{{ $properties.user }} = $ARTEMIS_USER_PW_{{ $user | upper | replace "-" "_" }}" >> /tmp/artemis/artemis-users.properties
+      {{- range $role := $properties.roles }}
+      echo "{{ $role }} = {{ $properties.user }}" >> /tmp/artemis/artemis-roles.properties
+      {{- end }}
+      {{- end }}
+      echo "Created config files:"
+      cat /tmp/artemis/artemis-users.properties
+      cat /tmp/artemis/artemis-roles.properties
+      echo "Set config file owner to 1000:1000 (artemis:artemis)..."
+      chown -R 1000:1000 /tmp/artemis
+      EOF
+  volumeMounts:
+  - name: artemis-users
+    mountPath: /tmp/artemis
 containers:
 - name: activemq-artemis 
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -160,6 +193,12 @@ containers:
     mountPath: /var/lib/artemis/etc-override
   - name: jgroups
     mountPath: /var/lib/artemis/etc/jgroups
+  - name: artemis-users
+    mountPath: /var/lib/artemis/etc/artemis-users.properties
+    subPath: artemis-users.properties
+  - name: artemis-users
+    mountPath: /var/lib/artemis/etc/artemis-roles.properties
+    subPath: artemis-roles.properties
 serviceAccount: {{ include "artemis.fullname" . }}
 {{- if .Values.podSecurityContext }}
 securityContext:
@@ -183,6 +222,8 @@ imagePullSecrets:
 {{- end }}
 volumes:
 - name: etc-override
+  emptyDir: {}
+- name: artemis-users
   emptyDir: {}
 - name: jgroups
   configMap:

--- a/src/main/helm/artemis/templates/_helpers.tpl
+++ b/src/main/helm/artemis/templates/_helpers.tpl
@@ -103,12 +103,11 @@ initContainers:
   image: {{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}
   imagePullPolicy: {{ .Values.initContainerImage.pullPolicy}}
   env:
-    {{- $releaseName := .Release.Name }}
     {{- range $user, $properties := .Values.users }}
     - name: ARTEMIS_USER_PW_{{ $user | upper | replace "-" "_" }}
       valueFrom:
         secretKeyRef:
-          name: {{ $releaseName }}-{{ $properties.secretName  }}
+          name: {{ $properties.secretName  }}
           key: {{ $properties.secretKey }}
     {{- end }}
   command:

--- a/src/main/helm/artemis/values.yaml
+++ b/src/main/helm/artemis/values.yaml
@@ -85,6 +85,18 @@ addressSettings:
       expiryAddress: ExpiryQueue
       messageCounterHistoryDayLimit: 10
 
+## users defines the Artemis users and roles required by other applications.
+# users:
+#    johndoe:
+#      user: johndoe
+#      secretName: artemis-secret
+#      secretKey: johndoe
+#      roles:
+#        - amq
+#        - someUserRole
+
+users: {}
+
 ## podSecurityContext allows setting security context for the pod: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 # podSecurityContext:
 ## containerSecurityContext allows setting security context for the container: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod

--- a/src/test/helm/artemis/values.yaml
+++ b/src/test/helm/artemis/values.yaml
@@ -1,0 +1,19 @@
+users:
+  artemisTestUser:
+    user: testUser1
+    secretName: test-secret
+    secretKey: test-user
+    roles:
+      - artemisRole1
+  artemisTestUser2:
+    user: testUser2
+    secretName: test-secret
+    secretKey: artemis-user
+    roles:
+      - artemisRole1
+      - artemisRole2
+      - amq
+  artemisTestUser3:
+    user: testUserNoRoles
+    secretName: test-secret
+    secretKey: no-roles


### PR DESCRIPTION
This adds the option to configure Artemis users with credentials and roles.

An additional init-container has been introduced to populate the required `artemis-users.properties` and `artemis-roles.properties` files, joining user/role settings from helm values with the respective passwords from individual secrets.

:information_source: Currently the passwords are stored in plaintext inside the containers.

:information_source: This still works with the `ARTEMIS_USERNAME` & `ARTEMIS_PASSWORD` environment variables. If they are set, they have higher priority.

Testing notes: I verified that it's possible to configure a user with role `amq` and that it's possible to login to the management console with that user at http://localhost:8161/console. In the future, it should probably be possible to further customize the permissions per roles.

DI note: The structure of the `users` helm-values-map should enable us to use this with our k8s secret provisioner.