### PR TITLE
Don't log user passwords on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Remove namespaces from roleRef and subjects as the namespace is defined for whole RoleBinding
 - Change 'empty' volume type to 'emptyDir'
+- Don't log the contents of artemis-users.properties and artemis-roles.properties on startup
 
 ### Changed
 - Expose prometheus service endpoint if `metrics.enabled` is `true`
 
 ### Added
-- Add option to configure artemis users, credentials and roles 
+- Add option to configure artemis users, credentials and roles
 
 ## [0.2.0] - 2020-05-20
 ### Changed

--- a/src/main/helm/artemis/templates/_helpers.tpl
+++ b/src/main/helm/artemis/templates/_helpers.tpl
@@ -122,9 +122,7 @@ initContainers:
       echo "{{ $role }} = {{ $properties.user }}" >> /tmp/artemis/artemis-roles.properties
       {{- end }}
       {{- end }}
-      echo "Created config files:"
-      cat /tmp/artemis/artemis-users.properties
-      cat /tmp/artemis/artemis-roles.properties
+      echo "Created config files"
       echo "Set config file owner to 1000:1000 (artemis:artemis)..."
       chown -R 1000:1000 /tmp/artemis
       EOF


### PR DESCRIPTION
Currently the contents of `artemis-users.properties` is printed to the console on startup. Since this file contains user passwords we should avoid doing that.